### PR TITLE
Fix broken links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,15 +16,15 @@ The inclusion of an ID makes referencing and linking easier. You can use the rul
 
 # Categories
 
-- Power Apps
-  - Model Driven Apps
-    - [Workflows](/PowerApps/ModelDrivenApps/Workflows.md)
+- Power Automate
+  - [Cloud Flows](/Power%20Automate/Cloud-Flows.md)
 - Power Pages
   - [Component Naming](/PowerPages/Component-Naming.md)
 - Dataverse
   - [Tables](/Dataverse/Tables.md)
   - [Forms](/Dataverse/Forms.md)
   - [Fields](/Dataverse/Fields.md)
+  - [Classic Workflows](/Dataverse/Classic-Workflows.md)
 
 # Contribution
 


### PR DESCRIPTION
## Summary

Fixes the README links to match the actual repository file structure.

### Changes
- **Removed broken link** — `/PowerApps/ModelDrivenApps/Workflows.md` pointed to a non-existent path
- **Added Power Automate section** — links to the existing `Power Automate/Cloud-Flows.md`
- **Added Classic Workflows** — links to the existing `Dataverse/Classic-Workflows.md`