### PR TITLE
Add CA-010: No cross-screen control references rule

### DIFF
--- a/Power Apps/Power-Apps.md
+++ b/Power Apps/Power-Apps.md
@@ -397,3 +397,39 @@ icoStatus.Color: If(ThisItem.Status = "Active", Green, Red)
 1. [Accessibility properties in Power Apps - Microsoft Learn](https://learn.microsoft.com/en-us/power-apps/maker/canvas-apps/controls/properties-accessibility)
 1. [Accessibility checker - Microsoft Learn](https://learn.microsoft.com/en-us/power-apps/maker/canvas-apps/accessibility-checker)
 1. [Web Content Accessibility Guidelines (WCAG) 2.1](https://www.w3.org/TR/WCAG21/)
+
+# CA-010: No Cross-Screen Control References
+
+Never reference controls from one screen on another screen. Each screen's formulas must only reference controls that belong to that same screen.
+
+1. Do not reference a control on `scrHome` from a formula on `scrDetails` or any other screen.
+1. Use variables (`Set()`, `UpdateContext()`) or collections to pass data between screens instead of directly referencing controls.
+1. Pass values via `Navigate()` context parameters when navigating from one screen to another.
+
+## Rationale
+
+1. Cross-screen control references create hidden dependencies between screens, making the app fragile and difficult to maintain.
+1. Power Apps does not guarantee that controls on other screens are initialized or hold the expected value when accessed from a different screen, leading to unpredictable behavior.
+1. Referencing controls across screens prevents Power Apps from unloading inactive screens from memory, increasing memory consumption and degrading performance.
+1. Using variables to pass data makes the data flow explicit and easier to trace during debugging.
+
+## Examples
+
+### Good
+
+```
+// On scrHome: navigate and pass the selected order via context variable
+Navigate(scrDetails, ScreenTransition.None, {locSelectedOrder: galOrders.Selected})
+
+// On scrDetails: use the context variable, not the gallery control from scrHome
+lblOrderTitle.Text: locSelectedOrder.Title
+lblOrderStatus.Text: locSelectedOrder.Status
+```
+
+### Bad
+
+```
+// On scrDetails: directly referencing a gallery on scrHome
+lblOrderTitle.Text: scrHome.galOrders.Selected.Title
+lblOrderStatus.Text: scrHome.galOrders.Selected.Status
+```

--- a/Power Apps/Power-Apps.md
+++ b/Power Apps/Power-Apps.md
@@ -398,7 +398,7 @@ icoStatus.Color: If(ThisItem.Status = "Active", Green, Red)
 1. [Accessibility checker - Microsoft Learn](https://learn.microsoft.com/en-us/power-apps/maker/canvas-apps/accessibility-checker)
 1. [Web Content Accessibility Guidelines (WCAG) 2.1](https://www.w3.org/TR/WCAG21/)
 
-# CA-010: No Cross-Screen Control References
+# CA-010
 
 Never reference controls from one screen on another screen. Each screen's formulas must only reference controls that belong to that same screen.
 


### PR DESCRIPTION
Canvas Apps currently lack a rule addressing cross-screen control references, which is a common source of bugs, hidden dependencies, and memory issues in Power Apps.

This adds **CA-010** to the Canvas Apps best practices, which prohibits referencing controls from one screen on another screen. The rule recommends using variables or `Navigate()` context parameters to pass data between screens instead. It includes rationale covering unpredictable behavior, memory impact, and maintainability, along with good/bad formula examples.